### PR TITLE
Fix README cookbook name typo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Requirements
 - Chef 12.2.0
 
 #### packages
-- `rvm::user_install` - User installation of rvm
+- `rvm_sl::user_install` - User installation of rvm
 
 Attributes
 ----------
 
-#### rvm::user_install
+#### rvm_sl::user_install
 
 See `attributes/user_install.rb` for default values.
 
@@ -58,15 +58,15 @@ end
 
 Usage
 -----
-#### rvm::user_install
+#### rvm_sl::user_install
 
-Just include `rvm::user_install` in your node's `run_list`:
+Just include `rvm_sl::user_install` in your node's `run_list`:
 
 ```json
 {
   "name":"my_node",
   "run_list": [
-    "recipe[rvm::user_install]"
+    "recipe[rvm_sl::user_install]"
   ]
 }
 ```


### PR DESCRIPTION
Hey there, I found some not-so-important typos in the readme's instructions regarding to the cookbook name.

Here and there the recipe name "rvm::user_install" was being used instead of "rvm_sl::user_install"