### PR TITLE
Added keyserver-options and changed gpg only_if

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,4 +4,4 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  rvm_sl (0.1.9)
+  rvm_sl (0.2.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ This file is used to list changes made in each version of the rvm cookbook.
 - Fix bats integration tests on ruby version
 - Adds serverspec integration tests on `.gemrc` presence
 
+0.2.1
+-----
+- Added attribute for node['rvm']['keyserver-options']
+- Changed only_if on gpg key to check if keys are in keyring
+
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Attributes
 See `attributes/user_install.rb` for default values.
 
 * `node['rvm']['keyserver']` - Key to import from key server
+* `node['rvm']['keyserver-options']` - Keyserver options to use
 * `node['rvm']['rcev-keys']` - Import the keys with the given key IDs from a keyserver
 * `node['rvm']['user']['name']` - The user name for rvm user install
 * `node['rvm']['user']['home']` - The home of the user

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'david.saenz.tagarro@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures user install of rvm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 
 recipe 'rvm::user_install', 'User installation of rvm'
 

--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -10,6 +10,7 @@
 username = node['rvm']['user']['name']
 home = node['rvm']['user']['home']
 keyserver = node['rvm']['keyserver']
+keyserver_options = node['rvm']['keyserver-options'].empty? ? '' : "--keyserver-options #{node['rvm']['keyserver-options']} "
 recv_keys = node['rvm']['recv-keys']
 
 include_recipe 'rvm_sl::system_requirements'
@@ -20,12 +21,12 @@ group 'rvm' do
 end
 
 execute 'installing_public_key' do
-  command "gpg --keyserver #{keyserver} --recv-keys #{recv_keys}"
+  command "gpg --keyserver #{keyserver} #{keyserver_options}--recv-keys #{recv_keys}"
   cwd home
   environment 'USER' => username, 'HOME' => home
   group 'rvm'
   user username
-  not_if 'which rvm'
+  not_if "gpg --list-keys #{recv_keys}"
 end
 
 execute 'installing_rvm' do


### PR DESCRIPTION
We can't always get to a keyserver.  I propose these two changes to be added.

Add keyserver-options for passing an "http-proxy=..." to gpg.  This fixes some cases for us and I have been passing this option in with the keyserver attribute as a hack.

Change the only_if check for fetching the gpg key so that the key can be pre-populated and user_install with not try to contact a keyserver.  That is what the only_if should be looking at anyway.
